### PR TITLE
Add return values & update requested access rights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.0.0-beta.2
+
+- Add return values, confirm success or failure
+- Add doc comments
+- Ensure process handle is closed after use
+- Misc cleanup
+
 # 1.0.0-beta.1
 
 - Prerelease version with updated dependencies, using dart sdk with null safety beta.

--- a/README.md
+++ b/README.md
@@ -8,16 +8,22 @@ To suspend:
 ```dart
 final process = Win32Process($pid);
 
-process.suspend();
+final bool suspended = process.suspend();
+
+if (!suspended) {
+    // Handle failure.
+}
 ```
 
 Then resume:
 
 ```dart
-process.resume();
+final bool resumed = process.resume();
+
+if (!resumed) {
+    // Handle failure.
+}
 ```
 
-The underlying Windows API supplies no return or confirmation, therefore these methods
-do not either.
 
 Further examples are provided in the examples directory.

--- a/example/advanced_example.dart
+++ b/example/advanced_example.dart
@@ -33,4 +33,7 @@ void main() {
     // Error handling.
   }
   print('Process resumed.');
+
+  // Release the handle to the process.
+  CloseHandle(processHandle);
 }

--- a/example/advanced_example.dart
+++ b/example/advanced_example.dart
@@ -15,16 +15,22 @@ void main() {
   final pid = 5588;
 
   // Get the handle to the process.
-  final processHandle = OpenProcess(PROCESS_ALL_ACCESS, FALSE, pid);
+  final processHandle = OpenProcess(PROCESS_SUSPEND_RESUME, FALSE, pid);
 
   // Suspend the process.
-  NtSuspendProcess(processHandle);
+  final suspended = NtSuspendProcess(processHandle);
+  if (suspended != 0) {
+    // Error handling.
+  }
   print('Process suspended.\nWaiting 10 seconds.');
 
   // Give a chance to see the process is suspended / unresponsive.
   sleep(Duration(seconds: 10));
 
   // Resume the process.
-  NtResumeProcess(processHandle);
+  final resumed = NtResumeProcess(processHandle);
+  if (resumed != 0) {
+    // Error handling.
+  }
   print('Process resumed.');
 }

--- a/example/example.dart
+++ b/example/example.dart
@@ -11,13 +11,19 @@ void main() {
   final process = Win32Process(pid);
 
   // Suspend the process.
-  process.suspend();
+  final suspended = process.suspend();
+  if (!suspended) {
+    // Error handling.
+  }
   print('Process suspended.\nWaiting 10 seconds.');
 
   // Give a chance to see the process is suspended / unresponsive.
   sleep(Duration(seconds: 10));
 
   // Resume the process.
-  process.resume();
+  final resumed = process.resume();
+  if (!resumed) {
+    // Error handling.
+  }
   print('Process resumed.');
 }

--- a/lib/src/ntdll.dart
+++ b/lib/src/ntdll.dart
@@ -5,29 +5,29 @@ import 'dart:ffi';
 final _ntdll = DynamicLibrary.open('ntdll.dll');
 
 /// The undocumented NtResumeProcess function accepts a process handle and
-/// resumes that process.
+/// resumes that process. Return value is 0 for success, non-zero for failure.
 ///
 /// ```c
-/// void NtResumeProcess(
+/// BOOL NtResumeProcess(
 ///  HWND hWnd
 /// );
 /// ```
-void NtResumeProcess(int hWnd) {
-  final _NtResumeProcess = _ntdll.lookupFunction<Void Function(IntPtr hWnd),
-      void Function(int hWnd)>('NtResumeProcess');
+int NtResumeProcess(int hWnd) {
+  final _NtResumeProcess = _ntdll.lookupFunction<Int32 Function(IntPtr hWnd),
+      int Function(int hWnd)>('NtResumeProcess');
   return _NtResumeProcess(hWnd);
 }
 
 /// The undocumented NtSuspendProcess function accepts a process handle and
-/// suspends that process.
+/// suspends that process. Return value is 0 for success, non-zero for failure.
 ///
 /// ```c
-/// void NtSuspendProcess(
+/// BOOL NtSuspendProcess(
 ///  HWND hWnd
 /// );
 /// ```
-void NtSuspendProcess(int hWnd) {
-  final _NtSuspendProcess = _ntdll.lookupFunction<Void Function(IntPtr hWnd),
-      void Function(int hWnd)>('NtSuspendProcess');
+int NtSuspendProcess(int hWnd) {
+  final _NtSuspendProcess = _ntdll.lookupFunction<Int32 Function(IntPtr hWnd),
+      int Function(int hWnd)>('NtSuspendProcess');
   return _NtSuspendProcess(hWnd);
 }

--- a/lib/src/process.dart
+++ b/lib/src/process.dart
@@ -26,26 +26,26 @@ import 'ntdll.dart';
 /// }
 /// ```
 class Win32Process {
-  Win32Process(this.pid)
-      : processHandle = OpenProcess(PROCESS_SUSPEND_RESUME, FALSE, pid);
+  Win32Process(this.pid);
 
   /// The process id of the process to be acted on.
   final int pid;
 
-  /// The win32 process handle.
-  final int processHandle;
-
   /// Returns true if the process was successfully suspended,
   /// returns false if it failed.
   bool suspend() {
+    final processHandle = OpenProcess(PROCESS_SUSPEND_RESUME, FALSE, pid);
     final result = NtSuspendProcess(processHandle);
+    CloseHandle(processHandle);
     return (result == 0) ? true : false;
   }
 
   /// Returns true if the process was successfully resumed,
   /// returns false if it failed.
   bool resume() {
+    final processHandle = OpenProcess(PROCESS_SUSPEND_RESUME, FALSE, pid);
     final result = NtResumeProcess(processHandle);
+    CloseHandle(processHandle);
     return (result == 0) ? true : false;
   }
 }

--- a/lib/src/process.dart
+++ b/lib/src/process.dart
@@ -9,24 +9,37 @@ import 'ntdll.dart';
 
 /// Suspend or resume processes on Microsoft Windows.
 ///
-/// Pass in the process id number and then call `suspend()` or `resume()`.
+/// Pass in the process id number when instantiating this object,
+/// then call the `suspend()` or `resume()` methods.
+///
+/// Returns true if successful, false if the call failed.
 ///
 /// #### Example
 ///
 /// ```dart
 /// var process = Win32Process([pid]);
 ///
-/// process.suspend();
+/// var result = process.suspend();
+///
+/// if (result != true) {
+///   // Handle error.
+/// }
 /// ```
 class Win32Process {
   Win32Process(this.pid)
-      : processHandle = OpenProcess(PROCESS_ALL_ACCESS, FALSE, pid);
+      : processHandle = OpenProcess(PROCESS_SUSPEND_RESUME, FALSE, pid);
 
   final int pid;
 
   final int processHandle;
 
-  void suspend() => NtSuspendProcess(processHandle);
+  bool suspend() {
+    var result = NtSuspendProcess(processHandle);
+    return (result == 0) ? true : false;
+  }
 
-  void resume() => NtResumeProcess(processHandle);
+  bool resume() {
+    var result = NtResumeProcess(processHandle);
+    return (result == 0) ? true : false;
+  }
 }

--- a/lib/src/process.dart
+++ b/lib/src/process.dart
@@ -17,9 +17,9 @@ import 'ntdll.dart';
 /// #### Example
 ///
 /// ```dart
-/// var process = Win32Process([pid]);
+/// final process = Win32Process([pid]);
 ///
-/// var result = process.suspend();
+/// final result = process.suspend();
 ///
 /// if (result != true) {
 ///   // Handle error.
@@ -38,14 +38,14 @@ class Win32Process {
   /// Returns true if the process was successfully suspended,
   /// returns false if it failed.
   bool suspend() {
-    var result = NtSuspendProcess(processHandle);
+    final result = NtSuspendProcess(processHandle);
     return (result == 0) ? true : false;
   }
 
   /// Returns true if the process was successfully resumed,
   /// returns false if it failed.
   bool resume() {
-    var result = NtResumeProcess(processHandle);
+    final result = NtResumeProcess(processHandle);
     return (result == 0) ? true : false;
   }
 }

--- a/lib/src/process.dart
+++ b/lib/src/process.dart
@@ -29,15 +29,21 @@ class Win32Process {
   Win32Process(this.pid)
       : processHandle = OpenProcess(PROCESS_SUSPEND_RESUME, FALSE, pid);
 
+  /// The process id of the process to be acted on.
   final int pid;
 
+  /// The win32 process handle.
   final int processHandle;
 
+  /// Returns true if the process was successfully suspended,
+  /// returns false if it failed.
   bool suspend() {
     var result = NtSuspendProcess(processHandle);
     return (result == 0) ? true : false;
   }
 
+  /// Returns true if the process was successfully resumed,
+  /// returns false if it failed.
   bool resume() {
     var result = NtResumeProcess(processHandle);
     return (result == 0) ? true : false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: win32_suspend_process
 description: >-
   Suspend and resume processes on the Windows platform from native dart code.
-version: 1.0.0-beta.1
+version: 1.0.0-beta.2
 homepage: https://github.com/Merrit/win32_suspend_process
 repository: https://github.com/Merrit/win32_suspend_process
 environment:

--- a/test/src/process_test.dart
+++ b/test/src/process_test.dart
@@ -4,8 +4,8 @@ import 'package:win32_suspend_process/src/process.dart';
 
 void main() {
   test('Can instantiate Win32Process', () {
-    var pid = io.pid;
-    var process = Win32Process(pid);
+    final pid = io.pid;
+    final process = Win32Process(pid);
     expect(process, isA<Win32Process>());
   });
 }


### PR DESCRIPTION
The ffi wrapper & convenience dart class can both now return something other than void, since it was discovered these functions do have a return value. This will make it easier to confirm success and failure.

OpenProcess() requested access rights was changed to PROCESS_SUSPEND_RESUME, being the absolute minimum we require & additionally it may improve compatability and reliability.

Also updated the comments, doc comments and examples to match.